### PR TITLE
DC命令のオペランド部でラベルの前方参照を行うと、ゼロ除算が発生する可能性があるバグを修正

### DIFF
--- a/Tasm7/src/SyntaxAnalyzer.java
+++ b/Tasm7/src/SyntaxAnalyzer.java
@@ -132,7 +132,10 @@ abstract class SyntaxAnalyzer {
         v *= factor(parser, symTbl, parseOnly);
       } else {
         parser.setNextTok(false);
-        v /= factor(parser, symTbl, parseOnly);
+        int rv = factor(parser, symTbl, parseOnly);
+        if (!parseOnly) {
+          v /= rv;
+        }
       }
       token = parser.getNextTok();
     }


### PR DESCRIPTION
DC命令のオペランド部にラベルの前方参照が含まれる場合、
そのラベルを常に１と仮定して構文解析を進めるため、
本来はゼロ除算が発生しない場合においてもゼロ除算が発生し、
正常にアセンブルできないバグを修正しました。

例
```
        DC      1 / (1 - A)
A       EQU     0
```